### PR TITLE
Inject database service and model as dependencies

### DIFF
--- a/app.js
+++ b/app.js
@@ -5,6 +5,9 @@ var passport = require('passport');
 var morgan = require('morgan');
 var bodyParser = require('body-parser');
 
+var databaseSvc = require('./utils/database.svc');
+var User = require('./models/user');
+
 var app = express();
 
 // CORS
@@ -34,7 +37,7 @@ app.use(bodyParser.json());
 app.use(passport.initialize());
 
 // Routes
-require('./features/auth/auth.ctrl')(router);
+require('./features/auth/auth.ctrl')(router, databaseSvc, User);
 app.use('/', router);
 
 // Catch 404 and forward to error handler

--- a/features/auth/auth.ctrl.js
+++ b/features/auth/auth.ctrl.js
@@ -1,9 +1,9 @@
 var responses = require('../../utils/responses');
-var authSvc = require('./auth.svc')();
 
-module.exports = function (router) {
+module.exports = function (router, databaseSvc, User) {
 	'use strict';
-	
+	var authSvc = require('./auth.svc')(databaseSvc, User);
+
 	function forgotPassword(req, res) {
 		authSvc
 			.forgotPassword(req)

--- a/features/auth/auth.svc.js
+++ b/features/auth/auth.svc.js
@@ -2,10 +2,8 @@ var passport = require('passport');
 var jwt = require('jwt-simple');
 var uuid = require('node-uuid');
 var Deferred = require('../../utils/deferred');
-var databaseSvc = require('../../utils/database.svc');
-var User = require('../../models/user');
 
-module.exports = function () {
+module.exports = function (databaseSvc, User) {
 	'use strict';
 
 	function register(req, res) {


### PR DESCRIPTION
Now it should be possible to hook up some other database beyond Mongo as long as the interface remains the same.

This means `databaseSvc` should implement `databaseSvc(model).findOne({...}).then(fn, fn)``. In addition `User` should provide `new User({email: <str>, verifyToken: <str>})` and `User.register(user, password, fn)`.

You may want do some tweaks to make the code suit your tastes better. This is a good first step towards something more general. After this you could think about dropping direct dependency to Mongo and perhaps clean up the interface I highlighted above.

Closes #7.