### PR TITLE
Replace `new`

### DIFF
--- a/app.js
+++ b/app.js
@@ -36,9 +36,10 @@ app.use(passport.initialize());
 var router = express.Router();
 app.use('/', router);
 
+var User = require('./src/models/user.js');
 require('./src/darklord.js')({
 	router: router,
-	databaseSvc: require('./src/database.svc.mongoose.js'),
+	databaseSvc: require('./src/database.svc.mongoose.js')(User),
 	user: User,
 	secret: process.env.JWT_SECRET || '85705984723056481905789579841057457023894570128572908173548590167438947918057893215791305728395767138075190574315674816510948'
 });

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   ],
   "main": "./src/darklord.js",
   "scripts": {
+    "start": "node ./app.js",
     "lint": "jshint . --exclude-path=.gitignore"
   },
   "dependencies": {


### PR DESCRIPTION
Looks like `register` actually does the same thing already so the `new` bit wasn't needed. I also added missing `npm start` and made sure passport gets initialized even if a model is provided. `app.js` wasn't working by default so I fixed it.